### PR TITLE
chore: HighScoreTextの位置を移動

### DIFF
--- a/Assets/Prefabs/HighScore Text.prefab
+++ b/Assets/Prefabs/HighScore Text.prefab
@@ -35,7 +35,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 15, y: -5}
   m_SizeDelta: {x: 300, y: 40}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &8583911584790043544

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -193,11 +193,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4432218688759255812, guid: be3a759442160524592453a2d2bf19b8, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 4432218688759255812, guid: be3a759442160524592453a2d2bf19b8, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -5
       objectReference: {fileID: 0}
     - target: {fileID: 4432218688759255812, guid: be3a759442160524592453a2d2bf19b8, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x

--- a/Assets/Scenes/Title.unity
+++ b/Assets/Scenes/Title.unity
@@ -1116,11 +1116,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4432218688759255812, guid: be3a759442160524592453a2d2bf19b8, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 4432218688759255812, guid: be3a759442160524592453a2d2bf19b8, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -5
       objectReference: {fileID: 0}
     - target: {fileID: 4432218688759255812, guid: be3a759442160524592453a2d2bf19b8, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -1398,7 +1398,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4958326256890953170, guid: a536903d48b81104daba0bccf04c18d6, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -40
+      value: -45
       objectReference: {fileID: 0}
     - target: {fileID: 4958326256890953170, guid: a536903d48b81104daba0bccf04c18d6, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x


### PR DESCRIPTION
## 行ったこと
- `HighScore Text`の位置を右に15、下に5移動
  - `Title`シーン、`Main`シーン両方で行った
- それに伴い、`HighScore Reset Button`の位置も下に5移動

## 目的
現状`HighScore Text`が画面端によりすぎており、見た目のバランスが悪く、また見切れやすいという問題があった。
したがって、これを移動させることによりバランスの調整を行った。
`HighScore Text`を下に移動させたことにより`HighScore Reset Button`との距離が近くなりすぎてしまったため、`HighScore Reset Button`の位置も同時に調整した。