### PR TITLE
feat: 画面クリックで加速する機能を追加

### DIFF
--- a/Assets/Scripts/GameActors/StoneController.cs
+++ b/Assets/Scripts/GameActors/StoneController.cs
@@ -13,13 +13,9 @@ public class StoneController : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        if (HasAccelerateInput)
-        {
-            if (referee != null && referee.CanAccelerate())
-            {
-                stone.TryAccelerate();
-            }
-        }
+        if (!HasAccelerateInput) return;
+        if (referee == null || !referee.CanAccelerate()) return;
+        stone.TryAccelerate();
     }
 
     private bool HasAccelerateInput => Input.GetKeyDown(KeyCode.Space) || Input.GetMouseButtonDown(0);


### PR DESCRIPTION
## 行ったこと
- 画面クリックで加速する機能を追加
- `StoneController`の`Update`メソッドのリファクタリング

## 目的
現状、ゲームスタートやリトライはクリック、加速はキーボードと操作方法が混在しており、プレイヤーが面倒に感じる可能性があった。
そのため、画面クリックでも加速できるようにし、マウス操作で完結するようにした。
なお、キーボード操作による加速機能は残した。

また、`if` 文のネストの深化や条件の複雑化の兆候が見えたため、リファクタリングを行った。
具体的には、以下を行った。
- 入力に関する条件をプロパティとして一つにまとめた
- 早期リターンを利用しネストを解消した

## 動作確認
プレイを行い、以下を確認した。
- マウスの左クリックでストーンが加速すること
- キーボードの`SPACE`キーでストーンが加速すること
- どちらの操作でもボーダーラインを越えた後加速しないこと
- どちらの操作でも加速度が変わらないこと（目視で確認）