### PR TITLE
ui: クレジットのテキストを変更

### DIFF
--- a/Assets/Scenes/Title.unity
+++ b/Assets/Scenes/Title.unity
@@ -744,7 +744,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: -75, y: 55}
+  m_AnchoredPosition: {x: -45, y: 55}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1546427442


### PR DESCRIPTION
## 行ったこと
- `Credit Text` の「サウンドエフェクト」の表記を「効果音」に変更
- `Credit Text` の表示位置を右に30移動

## 目的
現状、クレジットのテキストにおいて「サウンドエフェクト」の行のみ他より長く、見た目のバランスが悪かった。
そのため、表記を「効果音」に変更することにより、この問題を解決した。
また、表記の短縮により表示位置をもっと画面端に寄せることが可能になったため、移動を行った。
なお、`Fonts` は変更していないが、元々「効果音」の文字列はフォントに入っていたため（引用元の「効果音ラボ」の文字列）、問題は無いと思われる。

## 具体的なテキスト
```
制作：山口創也
BGM：魔王魂
効果音：効果音ラボ
開発エンジン：Unity
```

## 確認
プレイを行い、以下を確認した。
- クレジットのテキストがはみ出していないこと
- クレジットのテキストに文字化けが無いこと