### PR TITLE
refactor: ハイスコア取得メソッドを簡単化

### DIFF
--- a/Assets/Scripts/HighScore/HighScoreManager.cs
+++ b/Assets/Scripts/HighScore/HighScoreManager.cs
@@ -8,15 +8,8 @@ public class HighScoreManager
     // ハイスコアを返す
     public static Score GetHighScore()
     {
-        if (PlayerPrefs.HasKey(HighScoreKey))
-        {
-            float highScoreValue = PlayerPrefs.GetFloat(HighScoreKey);
-            return new Score(highScoreValue);
-        }
-        else
-        {
-            return new Score(DefaultHighScore);
-        }
+        float highScoreValue = PlayerPrefs.GetFloat(HighScoreKey, DefaultHighScore);
+        return new Score(highScoreValue);
     }
 
     // 現在のスコアの方が良いなら、更新する


### PR DESCRIPTION
## 行ったこと
- `HighScoreManager` の `GetHighScore` メソッドをリファクタリング
   - `PlayerPrefs.GetFloat` メソッドの第二引数を用いて分岐の必要をなくした

## 目的
現状、`GetHighScore` メソッドはキーの有無で場合分けが発生しており、冗長であった。
しかし、`PlayerPrefs.GetFloat` は第二引数にデフォルト値を設定することで、キーが存在しない場合その値を返すようにすることができる。
したがって、この機能を利用し、場合分けを省略した。

## 動作確認
プレイを行い、次のことを確認した。
- 新記録が出た時、ハイスコアの表示がその値に更新されること
- 新記録が出なかった時、ハイスコアの表示が変更されないこと
- ハイスコアのリセットを行った時、ハイスコアの表示がデフォルト値に更新されること