### PR TITLE
fix: ハイスコアのセーブの即時化

### DIFF
--- a/Assets/Scripts/HighScore/HighScoreManager.cs
+++ b/Assets/Scripts/HighScore/HighScoreManager.cs
@@ -19,6 +19,7 @@ public class HighScoreManager
         if (currentScore.IsBetterThan(highScore))
         {
             PlayerPrefs.SetFloat(HighScoreKey, currentScore.Value);
+            PlayerPrefs.Save();
         }
     }
 
@@ -26,5 +27,6 @@ public class HighScoreManager
     public static void ResetHighScore()
     {
         PlayerPrefs.SetFloat(HighScoreKey, DefaultHighScore);
+        PlayerPrefs.Save();
     }
 }


### PR DESCRIPTION
Closes #18

## 行ったこと
- ハイスコア更新時のセーブの即時化
- ハイスコアリセット時のセーブの即時化

## 目的
現状、ハイスコアのセーブはゲーム終了時に行う仕様になっている。
しかし、これでは異常終了時などでセーブが行われない可能性がある。
したがって、ハイスコア変更のたびにセーブを行うことで、この問題を防いだ。

## 動作確認
プレイを行い、次のことを確認した。
- ハイスコア更新やリセットが行えること
- 新記録が出なかった時にハイスコアがそのまま保持されること
- ハイスコア更新やリセットの結果が次回プレイ以降に持ち越せること
