### PR TITLE
chore: エディタにおけるConfirm Panelの表示設定を非表示に変更

### DIFF
--- a/Assets/Scenes/Title.unity
+++ b/Assets/Scenes/Title.unity
@@ -1695,7 +1695,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1038890230
 RectTransform:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## 行ったこと
- エディタにおける `Confirm Panel` の表示設定を非表示に変更

## 目的
エディタのTitleシーンにおいて、`Confirm Panel` が表示したままになってしまっており見づらかったので、設定を非表示に変更