### PR TITLE
fix: SeVolumeKeyを正しいものに修正

### DIFF
--- a/Assets/Scripts/Core/SoundManager.cs
+++ b/Assets/Scripts/Core/SoundManager.cs
@@ -24,7 +24,7 @@ public class SoundManager : MonoBehaviour
 
     /* ---音量の設定--- */
     private const string BgmVolumeKey = "BgmVolume";
-    private const string SeVolumeKey = "BgmVolume";
+    private const string SeVolumeKey = "SeVolume";
     private const float DefaultVolume = 0.7f;
 
     public float BgmVolume => bgmSource.volume;


### PR DESCRIPTION
## 行ったこと
- `SeVolumeKey` を `BgmVolume` から `SeVolume` に訂正

## 目的
現在 `SeVolumeKey` は `BgmVolumeKey` と同じ文字列となってしまっており、個別に保存することができていなかった。
したがって、文字列を `SeVolume` に訂正することでこれを解消した。

## 動作確認
プレイを行い、以下を確認した。
- BGMとSEが個別に音量変更を行えること
- BGMとSEの音量設定が個別に保存されていること