### PR TITLE
feat: エンターキーでの加速機能を追加

### DIFF
--- a/Assets/Scripts/GameActors/StoneController.cs
+++ b/Assets/Scripts/GameActors/StoneController.cs
@@ -1,3 +1,4 @@
+using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.InputSystem;
 
@@ -26,13 +27,16 @@ public class StoneController : MonoBehaviour
             // キーボードのスペースキーが押されたか
             bool isSpacePressed = Keyboard.current != null && Keyboard.current.spaceKey.wasPressedThisFrame;
 
+            // キーボードのエンターキーが押されたか
+            bool isEnterPressed = Keyboard.current != null && Keyboard.current.enterKey.wasPressedThisFrame;
+
             // マウスの左クリックが押されたか
             bool isMousePressed = Mouse.current != null && Mouse.current.leftButton.wasPressedThisFrame;
 
             // スマホなどの画面タップ（タッチパネル）が押されたか
             bool isTouched = Touchscreen.current != null && Touchscreen.current.primaryTouch.press.wasPressedThisFrame;
 
-            return isSpacePressed || isMousePressed || isTouched;
+            return isSpacePressed || isEnterPressed || isMousePressed || isTouched;
         }
     }
 }


### PR DESCRIPTION
Closes #24 

## 行ったこと
- キーボードの `ENTER` キーによるストーンの加速機能を追加

## 目的
現状、キーボードでの操作はボタン選択が `ENTER` 、加速が `SPACE` であり、行う操作によって使用キーの変更が必要であった。
したがって、`SPACE` キーでも加速を行えるようにし、キー操作を簡単化した。

## 動作確認
プレイを行い、以下を確認した。
- `ENTER` キーにより加速が行えること
- ボーダーラインを越えた後、`ENTER` キーを押しても加速しないこと
- `SPACE` キーと画面クリックによる操作に変化が無いこと