### PR TITLE
refactor: フォーカスの設定ロジックを静的メソッドを用いて一元化

### DIFF
--- a/Assets/Scripts/Core/GameResult.cs
+++ b/Assets/Scripts/Core/GameResult.cs
@@ -16,7 +16,7 @@ public class GameResult : MonoBehaviour
         Score score = new Score(stone.transform.position, house.transform.position);
         ShowResult(score);
         HighScoreManager.UpdateHighScore(score);
-        InitializeFocus();
+        FocusSetter.Set(initialSelectedObject);
     }
 
     // リザルトを表示する
@@ -31,15 +31,5 @@ public class GameResult : MonoBehaviour
         }
 
         resultUI.SetActive(true);
-    }
-
-    // フォーカスを初期化する
-    void InitializeFocus()
-    {
-        EventSystem.current.SetSelectedGameObject(null);
-        if (initialSelectedObject != null)
-        {
-            EventSystem.current.SetSelectedGameObject(initialSelectedObject);
-        }
     }
 }

--- a/Assets/Scripts/HighScore/HighScoreReseter.cs
+++ b/Assets/Scripts/HighScore/HighScoreReseter.cs
@@ -18,26 +18,14 @@ public class HighScoreReseter : MonoBehaviour
     public void OpenConfirmPanel()
     {
         confirmPanel.SetActive(true);
-
-        // フォーカスを合わせる
-        EventSystem.current.SetSelectedGameObject(null);
-        if (initialSelectedObject != null)
-        {
-            EventSystem.current.SetSelectedGameObject(initialSelectedObject);
-        }
+        FocusSetter.Set(initialSelectedObject);
     }
 
     // 確認パネルを閉じる
     public void CloseConfirmPanel()
     {
         confirmPanel.SetActive(false);
-
-        // フォーカスを合わせる
-        EventSystem.current.SetSelectedGameObject(null);
-        if (closedSelectedObject != null)
-        {
-            EventSystem.current.SetSelectedGameObject(closedSelectedObject);
-        }
+        FocusSetter.Set(closedSelectedObject);
     }
 
     // ハイスコアをリセットする

--- a/Assets/Scripts/Title/OptionPanelToggle.cs
+++ b/Assets/Scripts/Title/OptionPanelToggle.cs
@@ -31,25 +31,13 @@ public class OptionPanelToggle : MonoBehaviour
     public void OpenOption()
     {
         optionPanel.SetActive(true);
-
-        // フォーカスを合わせる
-        EventSystem.current.SetSelectedGameObject(null);
-        if (initialSelectedObject != null)
-        {
-            EventSystem.current.SetSelectedGameObject(initialSelectedObject);
-        }
+        FocusSetter.Set(initialSelectedObject);
     }
 
     // 設計パネルを閉じる
     public void CloseOption()
     {
         optionPanel.SetActive(false);
-
-        // フォーカスを合わせる
-        EventSystem.current.SetSelectedGameObject(null);
-        if (closedSelectedObject != null)
-        {
-            EventSystem.current.SetSelectedGameObject(closedSelectedObject);
-        }
+        FocusSetter.Set(closedSelectedObject);
     }
 }

--- a/Assets/Scripts/UI.meta
+++ b/Assets/Scripts/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 655f3c5c78e72ff429116dd4ac9e416c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/FocusSetter.cs
+++ b/Assets/Scripts/UI/FocusSetter.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+// フォーカスの設定を行う静的クラス
+public static class FocusSetter
+{
+    public static void Set(GameObject target)
+    {
+        EventSystem.current.SetSelectedGameObject(null);
+        if (target != null)
+        {
+            EventSystem.current.SetSelectedGameObject(target);
+        }
+    }
+}

--- a/Assets/Scripts/UI/FocusSetter.cs.meta
+++ b/Assets/Scripts/UI/FocusSetter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1adb7db5044ef934e9f7ef8fc14b9256


### PR DESCRIPTION
Closes #27 

## 行ったこと
- UI/FocusSetterに、フォーカス設定の静的メソッドを作成
- 既存コードのフォーカス設定部分をこのメソッドに置換
  - `GameResult`, `HighScoreReseter`, `OptionPanelToggle` の3ファイル
 
## 目的
現状のコードでは、フォーカスの設定と言うほぼ同じメソッドが何度も使いまわされており、冗長である。
また、フォーカスの設定方法を変えるときに、変更箇所が多くなるという問題点もある。
したがって、これらを1つのメソッドとして抽出を行い、処理を一元化した。

## 動作確認
プレイを行い、以下を確認した。
- オプション画面の開閉時に適切なオブジェクトにフォーカスされること
- 確認ポップアップの開閉時に適切なオブジェクトにフォーカスされること
- リザルト画面表示時に適切なオブジェクトにフォーカスされること