### PR TITLE
refactor: 得点計算をGameResultから分離

### DIFF
--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -1166,6 +1166,52 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &1609260004
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1609260006}
+  - component: {fileID: 1609260005}
+  m_Layer: 0
+  m_Name: Score Calculator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1609260005
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1609260004}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2eff68afcf4847c49b58ad27e043bb94, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ScoreCalculator
+  stone: {fileID: 784520689}
+  house: {fileID: 1863904945}
+--- !u!4 &1609260006
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1609260004}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1620844998
 GameObject:
   m_ObjectHideFlags: 0
@@ -1219,8 +1265,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f7ccf5a72c6903945a040f84a25aa2ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::GameResult
-  stone: {fileID: 784520689}
-  house: {fileID: 1863904945}
+  calculator: {fileID: 1609260005}
   resultUI: {fileID: 1620844998}
   resultText: {fileID: 2035924948}
   initialSelectedObject: {fileID: 414400841}
@@ -1967,6 +2012,7 @@ SceneRoots:
   - {fileID: 619394802}
   - {fileID: 5679625496655652420}
   - {fileID: 1090927218267863916}
+  - {fileID: 1609260006}
   - {fileID: 3510076726675237941}
   - {fileID: 4919517268569284142}
   - {fileID: 1550579842}

--- a/Assets/Scripts/Core/GameResult.cs
+++ b/Assets/Scripts/Core/GameResult.cs
@@ -4,8 +4,7 @@ using UnityEngine.EventSystems;
 
 public class GameResult : MonoBehaviour
 {
-    [SerializeField] private GameObject stone;
-    [SerializeField] private GameObject house;
+    [SerializeField] private ScoreCalculator calculator;
     [SerializeField] private GameObject resultUI;
     [SerializeField] private TextMeshProUGUI resultText;
     [SerializeField] private GameObject initialSelectedObject;
@@ -13,7 +12,7 @@ public class GameResult : MonoBehaviour
     // ゲーム終了時の処理
     public void EndGame()
     {
-        Score score = new Score(stone.transform.position, house.transform.position);
+        Score score = calculator.Calculate();
         ShowResult(score);
         HighScoreManager.UpdateHighScore(score);
         FocusSetter.Set(initialSelectedObject);

--- a/Assets/Scripts/Score/ScoreCalculator.cs
+++ b/Assets/Scripts/Score/ScoreCalculator.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+public class ScoreCalculator : MonoBehaviour
+{
+    [SerializeField] private GameObject stone;
+    [SerializeField] private GameObject house;
+
+    public Score Calculate()
+    {
+        return new Score(stone.transform.position, house.transform.position);
+    }
+}

--- a/Assets/Scripts/Score/ScoreCalculator.cs.meta
+++ b/Assets/Scripts/Score/ScoreCalculator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2eff68afcf4847c49b58ad27e043bb94


### PR DESCRIPTION
## 行ったこと
- 得点計算のロジックを`GameResult.cs` から `ScoreCalculator.cs` へ分離

## 目的
現在、`GameResult.cs` は得点計算には何のオブジェクトが必要かという踏み入った情報を知ってしまっている。
これにより、抽象度が低くなっている。
したがって、得点計算部分を分離するリファクタリングを行った。
またこれにより、計算の再利用性を高める目的もある。

## 動作確認
プレイを行い、以下を確認した。
- ストーンがハウスに近いほど得点が高いというルールが保たれていること
- ハイスコアの表示等が行えていること