### PR TITLE
refactor: IsStopメソッドのリファクタリング

### DIFF
--- a/Assets/Scripts/Core/GameReferee.cs
+++ b/Assets/Scripts/Core/GameReferee.cs
@@ -21,7 +21,7 @@ public class GameReferee
     // ゲームは終了したか判定
     public bool IsGameOver()
     {
-        return IsOverLine() && stone.IsStopped();
+        return IsOverLine() && stone.IsStopped;
     }
 
     // ボーダーラインを超えたか判定

--- a/Assets/Scripts/GameActors/Stone.cs
+++ b/Assets/Scripts/GameActors/Stone.cs
@@ -38,10 +38,7 @@ public class Stone : MonoBehaviour
     }
 
     // 停止しているか判定
-    public bool IsStopped()
-    {
-        return rb.linearVelocity == Vector2.zero;
-    }
+    public bool IsStopped => rb.linearVelocity == Vector2.zero;
 
     // 現在のX座標を返す
     public float CurrentX => transform.position.x;


### PR DESCRIPTION
Closes #45 

## 行ったこと
- `IsStop` を `IsStopped` へとリネーム
- `IsStopped` をプロパティ化

## 目的
現在、`IsStop` はメソッドとして実装されている。
しかし、引数が無い、計算コストがほぼゼロである、オブジェクトの状態を表すという点から、プロパティで書くことが望ましい。
また、英語として正しい名前となるよう、リネームも同時に行った。

## 動作確認
プレイを行い、以下を確認した。
- ゲームのリザルト表示が正常なタイミングで行われること
- リザルト表示後に動かすことができないこと