### PR TITLE
fix: 背景及びMainシーンのボーダーラインを拡大

### DIFF
--- a/Assets/Prefabs/Stage.prefab
+++ b/Assets/Prefabs/Stage.prefab
@@ -27,13 +27,14 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 2, y: 0, z: 0}
-  m_LocalScale: {x: 0.2, y: 12, z: 1}
+  m_LocalScale: {x: 0.2, y: 24, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2120353730090575446}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &3312327157965643660
 SpriteRenderer:
+  serializedVersion: 2
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -79,6 +80,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 1
+  m_MaskInteraction: 0
   m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
   m_Color: {r: 1, g: 0, b: 0, a: 1}
   m_FlipX: 0
@@ -88,7 +90,6 @@ SpriteRenderer:
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
   m_SpriteSortPoint: 0
 --- !u!1 &3891067978637052409
 GameObject:
@@ -117,13 +118,14 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 20, y: 12, z: 1}
+  m_LocalScale: {x: 40, y: 24, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2120353730090575446}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &4647552696791885242
 SpriteRenderer:
+  serializedVersion: 2
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -169,6 +171,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
@@ -178,7 +181,6 @@ SpriteRenderer:
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
   m_SpriteSortPoint: 0
 --- !u!1 &7463120099593346199
 GameObject:
@@ -248,6 +250,7 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &4165871939066226188
 SpriteRenderer:
+  serializedVersion: 2
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -293,6 +296,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 1
+  m_MaskInteraction: 0
   m_Sprite: {fileID: -1923994175756728024, guid: e29418afcae329b4e82189b6b13c1b9d, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
@@ -302,5 +306,4 @@ SpriteRenderer:
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
   m_SpriteSortPoint: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -1740,6 +1740,18 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 181467425773338169, guid: 6f179fddac4142f47a75f6ef8059a042, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 181467425773338169, guid: 6f179fddac4142f47a75f6ef8059a042, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 24
+      objectReference: {fileID: 0}
+    - target: {fileID: 733328741997651668, guid: 6f179fddac4142f47a75f6ef8059a042, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 24
+      objectReference: {fileID: 0}
     - target: {fileID: 2120353730090575446, guid: 6f179fddac4142f47a75f6ef8059a042, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0

--- a/Assets/Scenes/Title.unity
+++ b/Assets/Scenes/Title.unity
@@ -1016,7 +1016,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 20, y: 12, z: 1}
+  m_LocalScale: {x: 40, y: 24, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}


### PR DESCRIPTION
Closes #59 

## 行ったこと
- UnityのGameタブにて選択可能なアスペクト比に、21:9を追加（スマホ横画面を意識）
- Titleシーンの `Background` オブジェクトの拡大
  - 縦横とも2倍にした
- `Stage` プレハブの `Floor` と `Border Line` オブジェクトの拡大
  - `Floor` は縦横2倍、`Border Line` は縦に2倍にした。
  - 同時に、Mainシーンのこれらも拡大された。

## 目的
スマートフォンでプレイした場合、背景の横幅が画面の横幅より小さく、ボタンなどの一部UIが背景からはみ出してしまうという不具合があった。
そのため、これを各オブジェクトを拡大することにより解消した。

## 確認
プレイを行い、以下を確認した。
- アスペクト比21:9にて、Titleシーンにおける背景が横幅以上になっていること
- 同アスペクト比にて、Mainシーンにおける背景が横幅以上になっていること
- 他アスペクト比においても、背景が横幅以上になっていることを確認した

なお、`Option Button` にてアスペクト比21:9の場合、フォーカスの移動先が意図していたものと異なる不具合が発覚したので、こちらもこの後直すこととする。