### PR TITLE
fix: OptionButtonのフォーカス移動先の設定をExplicitに変更

### DIFF
--- a/Assets/Scenes/Title.unity
+++ b/Assets/Scenes/Title.unity
@@ -1543,7 +1543,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 47785808217664240, guid: 0ef9d67478fa96a479318745e5b866a7, type: 3}
       propertyPath: m_Navigation.m_Mode
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 47785808217664240, guid: 0ef9d67478fa96a479318745e5b866a7, type: 3}
       propertyPath: m_Colors.m_PressedColor.b
@@ -1585,6 +1585,14 @@ PrefabInstance:
       propertyPath: m_Colors.m_SelectedColor.r
       value: 0.8627451
       objectReference: {fileID: 0}
+    - target: {fileID: 47785808217664240, guid: 0ef9d67478fa96a479318745e5b866a7, type: 3}
+      propertyPath: m_Navigation.m_SelectOnDown
+      value: 
+      objectReference: {fileID: 2140839757}
+    - target: {fileID: 47785808217664240, guid: 0ef9d67478fa96a479318745e5b866a7, type: 3}
+      propertyPath: m_Navigation.m_SelectOnLeft
+      value: 
+      objectReference: {fileID: 4744704544310213565}
     - target: {fileID: 451375028838371473, guid: 0ef9d67478fa96a479318745e5b866a7, type: 3}
       propertyPath: m_Navigation.m_Mode
       value: 4


### PR DESCRIPTION
Closes #61 

## 行ったこと
- `Option Button` のフォーカス移動先を以下のように固定
  - 左入力：`HighScore Reset Button`
  - 下入力：`Start Button`
  - その他：`none`

## 目的
特定のアスペクト比で、`Option Button`にフォーカスされているときの移動先が、意図と異なるものになる不具合が存在する。
そのため、フォーカス移動先を固定することによりこれを改善した。

## 動作確認
プレイを行い、フォーカスの移動が適切に行われることを確認した。